### PR TITLE
fix set('name', 'value') and set('foo.bar', 'value') going to the same logic issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class Config {
   set(name, value) {
     if (name.indexOf('.') === -1) {
       this.config[name] = value;
+      return this;
     }
     let config = this.config;
     name = name.split('.');


### PR DESCRIPTION
The set function should return immediately when `name` does't contain dot. Although it turns out to be the same without bug :) .

Before:

```javascript
set(name, value) {
  if (name.indexOf('.') === -1) {
    this.config[name] = value;
  }
  // name with dot inside logic
  // ...
}
```

After:

```javascript
set(name, value) {
  if (name.indexOf('.') === -1) {
    this.config[name] = value;
    return this;
  }
  // name with dot inside logic
  // ...
}
```